### PR TITLE
Add ErrNotModified

### DIFF
--- a/pkg/derr/errors.go
+++ b/pkg/derr/errors.go
@@ -58,4 +58,5 @@ var (
 	ErrProtoValidate                 = cerr.NewAsertoError("E20050", codes.InvalidArgument, http.StatusBadRequest, "")
 	ErrGraphDirectionality           = cerr.NewAsertoError("E20052", codes.InvalidArgument, http.StatusPreconditionFailed, "unable to determine graph directionality")
 	ErrUnknownOpCode                 = cerr.NewAsertoError("E20053", codes.InvalidArgument, http.StatusPreconditionFailed, "unknown import OpCode value")
+	ErrNotModified                   = cerr.NewAsertoError("E20054", codes.FailedPrecondition, http.StatusNotModified, "not modified")
 )


### PR DESCRIPTION
This error message will be used when we check the `IfNotMatch` header in GetObject and GetRelation in https://github.com/aserto-dev/directory/pull/363