### PR TITLE
ErrNotImplemented + ErrCycleDetected

### DIFF
--- a/pkg/convert/convert.go
+++ b/pkg/convert/convert.go
@@ -99,27 +99,6 @@ func ObjectArrayToV3(in []*dsc2.Object) []*dsc3.Object {
 	return result
 }
 
-func ObjectDependencyToV3(in *dsc2.ObjectDependency) *dsc3.ObjectDependency {
-	return &dsc3.ObjectDependency{
-		ObjectType:  in.GetObjectType(),
-		ObjectId:    in.GetObjectKey(),
-		Relation:    in.GetRelation(),
-		SubjectType: in.GetSubjectType(),
-		SubjectId:   in.GetSubjectKey(),
-		Depth:       in.GetDepth(),
-		IsCycle:     in.GetIsCycle(),
-		Path:        in.GetPath(),
-	}
-}
-
-func ObjectDependencyArrayToV3(in []*dsc2.ObjectDependency) []*dsc3.ObjectDependency {
-	result := make([]*dsc3.ObjectDependency, len(in))
-	for i := 0; i < len(in); i++ {
-		result[i] = ObjectDependencyToV3(in[i])
-	}
-	return result
-}
-
 func RelationToV2(in *dsc3.Relation) *dsc2.Relation {
 	return &dsc2.Relation{
 		Object: &dsc2.ObjectIdentifier{
@@ -250,18 +229,6 @@ func CheckPermissionRequestToV3(in *dsr2.CheckPermissionRequest) *dsr3.CheckPerm
 		SubjectType: in.GetSubject().GetType(),
 		SubjectId:   in.GetSubject().GetKey(),
 		Trace:       in.GetTrace(),
-	}
-}
-
-func GetGraphRequestToV3(in *dsr2.GetGraphRequest) *dsr3.GetGraphRequest {
-	return &dsr3.GetGraphRequest{
-		AnchorType:  in.GetAnchor().GetType(),
-		AnchorId:    in.GetAnchor().GetKey(),
-		ObjectType:  in.GetObject().GetType(),
-		ObjectId:    in.GetObject().GetKey(),
-		Relation:    in.GetRelation().GetName(),
-		SubjectType: in.GetSubject().GetType(),
-		SubjectId:   in.GetSubject().GetKey(),
 	}
 }
 

--- a/pkg/derr/errors.go
+++ b/pkg/derr/errors.go
@@ -47,4 +47,5 @@ var (
 	ErrGraphDirectionality          = cerr.NewAsertoError("E20052", codes.InvalidArgument, http.StatusPreconditionFailed, "unable to determine graph directionality")
 	ErrUnknownOpCode                = cerr.NewAsertoError("E20053", codes.InvalidArgument, http.StatusPreconditionFailed, "unknown import OpCode value")
 	ErrNotImplemented               = cerr.NewAsertoError("E20054", codes.Unimplemented, http.StatusNotImplemented, "not implemented")
+	ErrCycleDetected                = cerr.NewAsertoError("E20055", codes.FailedPrecondition, http.StatusPreconditionFailed, "cycle detected")
 )

--- a/pkg/derr/errors.go
+++ b/pkg/derr/errors.go
@@ -46,4 +46,5 @@ var (
 	ErrProtoValidate                = cerr.NewAsertoError("E20050", codes.InvalidArgument, http.StatusBadRequest, "")
 	ErrGraphDirectionality          = cerr.NewAsertoError("E20052", codes.InvalidArgument, http.StatusPreconditionFailed, "unable to determine graph directionality")
 	ErrUnknownOpCode                = cerr.NewAsertoError("E20053", codes.InvalidArgument, http.StatusPreconditionFailed, "unknown import OpCode value")
+	ErrNotImplemented               = cerr.NewAsertoError("E20054", codes.Unimplemented, http.StatusNotImplemented, "not implemented")
 )


### PR DESCRIPTION
Adding error codes used by the new GetGraph implementation.


This PR also removes references to `v3.ObjectDependency` which is being removed in https://github.com/aserto-dev/pb-directory/pull/70.